### PR TITLE
Upgrade NGINX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ LABEL maintainer="Eric Martinez <emartinez@usgs.gov>" \
       dockerfile_version="1.0.0"
 
 
-RUN yum install -y epel-release && \
-    yum install -y nginx && \
+COPY ./nginx.repo /etc/yum.repos.d/nginx.repo
+
+RUN yum install -y nginx && \
     yum clean all && \
     rm -rf /etc/nginx /usr/share/nginx/html && \
     mkdir -p /etc/nginx /usr/share/nginx/html && \
@@ -16,8 +17,9 @@ RUN yum install -y epel-release && \
         /startup-hooks \
         /usr/share/nginx \
         /var/log/nginx \
-        /var/lib/nginx \
-        /var/run /run
+        /var/cache/nginx \
+        /var/run \
+        /run
 
 COPY ./conf/ /etc/nginx/
 COPY ./html/ /usr/share/nginx/html
@@ -27,13 +29,7 @@ COPY ./healthcheck.sh /healthcheck.sh
 # Create a self-signed certificate so the build doesn't blow up by default.
 # If actually using SSL, a user will likely want to provide actual certificate
 # files for the target deployment.
-RUN chown -R usgs-user \
-      /usr/share/nginx \
-      /etc/nginx \
-      /var/log/nginx \
-      /var/lib/nginx \
-      /var/run /run && \
-    openssl \
+RUN openssl \
       req \
       -x509 \
       -nodes \

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -51,7 +51,6 @@ http {
     server_name  _;
     root         /usr/share/nginx/html;
 
-    ssl                        on;
     ssl_certificate_key        /etc/nginx/ssl/server.key;
     ssl_certificate            /etc/nginx/ssl/server.crt;
     ssl_ciphers                ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS;

--- a/nginx.repo
+++ b/nginx.repo
@@ -1,0 +1,5 @@
+[nginx]
+name=nginx repo
+baseurl=http://nginx.org/packages/mainline/centos/7/$basearch/
+gpgcheck=0
+enabled=1


### PR DESCRIPTION
Not installing epel; no longer used. Instead use nginx.repo to get latest version (currently 1.17.3). Update configuration for new version. Remove some redundant stuff.

The end result is NGINX will run the latest version and vulnerabilities are remedied.